### PR TITLE
chore: sort and remove unused imports across codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,22 @@
 {
   "extends": ["next", "next/core-web-vitals", "eslint:recommended"],
+  "plugins": ["unused-imports", "simple-import-sort"],
   "globals": {
     "React": "readonly"
   },
   "rules": {
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ],
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  },
   "editor.formatOnSave": true,
   "sqltools.useNodeRuntime": true,
   "sqltools.connections": [

--- a/e2e/001-dashboard.spec.ts
+++ b/e2e/001-dashboard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("has title", async ({ page }) => {
   await page.goto("http://localhost:3001/");

--- a/e2e/002-company.spec.ts
+++ b/e2e/002-company.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo } from "./helper";
 
 const companyName = "Dummy company";

--- a/e2e/003-mutual-fund.spec.ts
+++ b/e2e/003-mutual-fund.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo } from "./helper";
 
 const mutualFundName = "test mutual fund";

--- a/e2e/004-buy-stock.spec.ts
+++ b/e2e/004-buy-stock.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo, selectDate } from "./helper";
 
 const companyName = "Clean Science & Technology Ltd.";

--- a/e2e/005-buy-mf.spec.ts
+++ b/e2e/005-buy-mf.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo, selectDate } from "./helper";
 
 const mutualFundName = "Parag Parikh Flexi Cap Fund - Direct Plan - Growth";

--- a/e2e/006-fund-transfer.spec.ts
+++ b/e2e/006-fund-transfer.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo, selectDate } from "./helper";
 
 test.beforeEach(async ({ page }) => {

--- a/e2e/007-dividend.spec.ts
+++ b/e2e/007-dividend.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo, selectDate } from "./helper";
 
 test.beforeEach(async ({ page }) => {

--- a/e2e/008-reports.spec.ts
+++ b/e2e/008-reports.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
 import { selectCombo } from "./helper";
 
 test.beforeEach(async ({ page }) => {

--- a/e2e/009-settings.spec.ts
+++ b/e2e/009-settings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
   // Runs before each test and signs in each page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,8 @@
         "@vitest/ui": "^3.0.9",
         "eslint": "^8",
         "eslint-config-next": "15.2.3",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "husky": "^9.1.7",
         "jsdom": "^24.1.1",
         "npm-check-updates": "^17.1.16",
@@ -7172,6 +7174,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "@vitest/ui": "^3.0.9",
     "eslint": "^8",
     "eslint-config-next": "15.2.3",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "husky": "^9.1.7",
     "jsdom": "^24.1.1",
     "npm-check-updates": "^17.1.16",

--- a/src/actions/annual-return.service.ts
+++ b/src/actions/annual-return.service.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import AnualReturn, { AnnualReturnType } from "@/models/annual-return.model";
+
 import { connectDB } from "./base.service";
 
 export async function getAnnualReturn(exchange: string): Promise<AnnualReturnType[]> {

--- a/src/actions/company.service.ts
+++ b/src/actions/company.service.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import Company, { CompanyType } from "@/models/company.model";
+
 import { connectDB } from "./base.service";
 
 export async function getCompanies(): Promise<CompanyType[]> {

--- a/src/actions/connection.service.ts
+++ b/src/actions/connection.service.ts
@@ -1,11 +1,12 @@
 import { Sequelize } from "sequelize-typescript";
-import Company from "@/models/company.model";
-import StockInvestment from "@/models/stock-investment.model";
-import MutualFundInvestment from "@/models/mutual-fund-investment.model";
-import MutualFund from "@/models/mutual-fund.model";
-import Deposit from "@/models/deposit.model";
-import Sale from "@/models/sale.model";
+
 import AnnualReturn from "@/models/annual-return.model";
+import Company from "@/models/company.model";
+import Deposit from "@/models/deposit.model";
+import MutualFund from "@/models/mutual-fund.model";
+import MutualFundInvestment from "@/models/mutual-fund-investment.model";
+import Sale from "@/models/sale.model";
+import StockInvestment from "@/models/stock-investment.model";
 
 export class ConnectionService {
   static sequelize: Sequelize;

--- a/src/actions/dashboard.service.ts
+++ b/src/actions/dashboard.service.ts
@@ -1,8 +1,10 @@
 "use server";
 
 import { QueryTypes } from "sequelize";
-import { connectDB } from "./base.service";
+
 import { getCompountedInterest } from "@/lib/financial";
+
+import { connectDB } from "./base.service";
 
 export type TotalInvestmentType = {
   totalINRInvestments: number;

--- a/src/actions/mutual-fund-investment.service.ts
+++ b/src/actions/mutual-fund-investment.service.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import MutualFundInvestment, { MutualFundInvestmentType } from "../models/mutual-fund-investment.model";
 import MutualFund from "../models/mutual-fund.model";
+import MutualFundInvestment, { MutualFundInvestmentType } from "../models/mutual-fund-investment.model";
 import { connectDB } from "./base.service";
 
 export async function getMutualFundInvestments(): Promise<MutualFundInvestment[]> {

--- a/src/actions/purchase-detail.service.ts
+++ b/src/actions/purchase-detail.service.ts
@@ -1,11 +1,13 @@
 "use server";
 
-import { QueryTypes } from "sequelize";
-import { connectDB } from "./base.service";
-import { calculateCAGR, calculateInterest, calculateXIRR } from "@/lib/financial";
-import { orderBy, round } from "lodash";
 import { parseISO } from "date-fns";
+import { orderBy, round } from "lodash";
+import { QueryTypes } from "sequelize";
+
 import { StockOrMutualFundType } from "@/lib/constants";
+import { calculateCAGR, calculateInterest, calculateXIRR } from "@/lib/financial";
+
+import { connectDB } from "./base.service";
 
 type InvestmentGrouthRate = {
   percentage10: number;

--- a/src/actions/report.service.ts
+++ b/src/actions/report.service.ts
@@ -1,10 +1,12 @@
 "use server";
 
-import { QueryTypes } from "sequelize";
-import { connectDB } from "./base.service";
 import { parse } from "date-fns";
 import { round, slice, sortBy, sumBy } from "lodash";
+import { QueryTypes } from "sequelize";
+
 import { calculateInterest } from "@/lib/financial";
+
+import { connectDB } from "./base.service";
 export type MonthlyInvestmentType = {
   month: Date;
   stocks: number;

--- a/src/actions/sale.service.ts
+++ b/src/actions/sale.service.ts
@@ -1,11 +1,12 @@
 "use server";
 
-import Sale, { SaleType } from "../models/sale.model";
-import { getStockInvestmentByID } from "./stock-investment.service";
-import { connectDB } from "./base.service";
 import { StockOrMutualFundType } from "@/lib/constants";
-import { deleteMutualFundInvestment } from "./mutual-fund-investment.service";
 import StockInvestment from "@/models/stock-investment.model";
+
+import Sale, { SaleType } from "../models/sale.model";
+import { connectDB } from "./base.service";
+import { deleteMutualFundInvestment } from "./mutual-fund-investment.service";
+import { getStockInvestmentByID } from "./stock-investment.service";
 
 export async function addSales(sale: SaleType, type: StockOrMutualFundType, investmentID: number): Promise<SaleType | null> {
   let transaction;

--- a/src/app/companies/create/page.tsx
+++ b/src/app/companies/create/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from "next";
+
 import AddModifyCompany, { CompanyFormValues } from "@/components/companies/add-modify-company";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Companies",

--- a/src/app/companies/edit/[id]/page.tsx
+++ b/src/app/companies/edit/[id]/page.tsx
@@ -1,7 +1,8 @@
+import { Metadata } from "next";
+
 import { getCompanyByID } from "@/actions/company.service";
 import AddModifyCompany, { CompanyFormValues } from "@/components/companies/add-modify-company";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Companies",

--- a/src/app/companies/page.tsx
+++ b/src/app/companies/page.tsx
@@ -1,8 +1,8 @@
-import { DataTable } from "@/components/companies/data-table/data-table";
-
 import { Metadata } from "next";
+
 import { getCompanies } from "@/actions/company.service";
 import { Columns } from "@/components/companies/data-table/columns";
+import { DataTable } from "@/components/companies/data-table/data-table";
 
 export const metadata: Metadata = {
   title: "StockSync : Companies",

--- a/src/app/dividend/create/page.tsx
+++ b/src/app/dividend/create/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from "next";
+
 import AddModifyDeposit, { DepositFormValues } from "@/components/deposit/add-modify-deposit";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Dividend",

--- a/src/app/dividend/edit/[id]/page.tsx
+++ b/src/app/dividend/edit/[id]/page.tsx
@@ -1,8 +1,9 @@
+import { toDate } from "date-fns";
+import { Metadata } from "next";
+
 import { getDepositByID } from "@/actions/deposit.service";
 import AddModifyDeposit, { DepositFormValues } from "@/components/deposit/add-modify-deposit";
 import { Separator } from "@/components/ui/separator";
-import { toDate } from "date-fns";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Dividend",

--- a/src/app/dividend/page.tsx
+++ b/src/app/dividend/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+
 import { getDeposits } from "@/actions/deposit.service";
 import { Columns } from "@/components/deposit/data-table/columns";
 import { DataTable } from "@/components/deposit/data-table/data-table";

--- a/src/app/fund-transfer/create/page.tsx
+++ b/src/app/fund-transfer/create/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from "next";
+
 import AddModifyDeposit, { DepositFormValues } from "@/components/deposit/add-modify-deposit";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Fund transfer",

--- a/src/app/fund-transfer/edit/[id]/page.tsx
+++ b/src/app/fund-transfer/edit/[id]/page.tsx
@@ -1,8 +1,9 @@
+import { toDate } from "date-fns";
+import { Metadata } from "next";
+
 import { getDepositByID } from "@/actions/deposit.service";
 import AddModifyDeposit, { DepositFormValues } from "@/components/deposit/add-modify-deposit";
 import { Separator } from "@/components/ui/separator";
-import { toDate } from "date-fns";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Fund transfer",

--- a/src/app/fund-transfer/page.tsx
+++ b/src/app/fund-transfer/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+
 import { getDeposits } from "@/actions/deposit.service";
 import { Columns } from "@/components/deposit/data-table/columns";
 import { DataTable } from "@/components/deposit/data-table/data-table";

--- a/src/app/investments/mutual-fund/create/page.tsx
+++ b/src/app/investments/mutual-fund/create/page.tsx
@@ -1,7 +1,8 @@
+import { Metadata } from "next";
+
 import AddModifyMFInvestment from "@/components/investments/mutual-fund/add-modify-mf-investment";
 import { StockInvestmentFormValues } from "@/components/investments/stocks/add-modify-stock-investment";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Investments",

--- a/src/app/investments/mutual-fund/edit/[id]/page.tsx
+++ b/src/app/investments/mutual-fund/edit/[id]/page.tsx
@@ -1,8 +1,9 @@
+import { toDate } from "date-fns";
+import { Metadata } from "next";
+
 import { getMutualFundInvestmentByID } from "@/actions/mutual-fund-investment.service";
 import AddModifyMFInvestment, { MutualFundInvestmentFormValues } from "@/components/investments/mutual-fund/add-modify-mf-investment";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
-import { toDate } from "date-fns";
 
 export const metadata: Metadata = {
   title: "StockSync : Investments",

--- a/src/app/investments/mutual-fund/page.tsx
+++ b/src/app/investments/mutual-fund/page.tsx
@@ -1,8 +1,9 @@
+import { Metadata } from "next";
+
 import { getMutualFundInvestments } from "@/actions/mutual-fund-investment.service";
 import { Columns } from "@/components/investments/mutual-fund/data-table/columns";
 import { DataTable } from "@/components/investments/mutual-fund/data-table/data-table";
 import MutualFundInvestment from "@/models/mutual-fund-investment.model";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Investments",

--- a/src/app/investments/stocks/create/page.tsx
+++ b/src/app/investments/stocks/create/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from "next";
+
 import AddModifyStockInvestment, { StockInvestmentFormValues } from "@/components/investments/stocks/add-modify-stock-investment";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Investments",

--- a/src/app/investments/stocks/edit/[id]/page.tsx
+++ b/src/app/investments/stocks/edit/[id]/page.tsx
@@ -1,8 +1,9 @@
-import { getStockInvestmentByID } from "@/actions/stock-investment.service";
-import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 import { toDate } from "date-fns";
+import { Metadata } from "next";
+
+import { getStockInvestmentByID } from "@/actions/stock-investment.service";
 import AddModifyStockInvestment, { StockInvestmentFormValues } from "@/components/investments/stocks/add-modify-stock-investment";
+import { Separator } from "@/components/ui/separator";
 
 export const metadata: Metadata = {
   title: "StockSync : Investments",

--- a/src/app/investments/stocks/page.tsx
+++ b/src/app/investments/stocks/page.tsx
@@ -1,8 +1,9 @@
+import { Metadata } from "next";
+
 import { getStockInvestments } from "@/actions/stock-investment.service";
 import { Columns } from "@/components/investments/stocks/data-table/columns";
 import { DataTable } from "@/components/investments/stocks/data-table/data-table";
 import { StockInvestmentType } from "@/models/stock-investment.model";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Investments",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
+import "./globals.css";
+
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
+
 import { SiteHeader } from "@/components/site-header";
 import { Toaster } from "@/components/ui/toaster";
 

--- a/src/app/mutual-fund/create/page.tsx
+++ b/src/app/mutual-fund/create/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from "next";
+
 import AddModifyMutualFund, { MutualFundFormValues } from "@/components/mutual-fund/add-modify-mutualfund";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Mutual Fund",

--- a/src/app/mutual-fund/edit/[id]/page.tsx
+++ b/src/app/mutual-fund/edit/[id]/page.tsx
@@ -1,7 +1,8 @@
+import { Metadata } from "next";
+
 import { getMFByID } from "@/actions/mutual-fund.service";
 import AddModifyMutualFund, { MutualFundFormValues } from "@/components/mutual-fund/add-modify-mutualfund";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Mutual Fund",

--- a/src/app/mutual-fund/page.tsx
+++ b/src/app/mutual-fund/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+
 import { getMFs } from "@/actions/mutual-fund.service";
 import { Columns } from "@/components/mutual-fund/data-table/columns";
 import { DataTable } from "@/components/mutual-fund/data-table/data-table";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
+import { Metadata } from "next";
+
 import { getDashboardOverview } from "@/actions/dashboard.service";
 import { Dashboard } from "@/components/dashboard/dashboard";
-
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Dashboard",

--- a/src/app/reports/annual-return/create/page.tsx
+++ b/src/app/reports/annual-return/create/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from "next";
+
 import AddModifyAnnualReturn, { AnnualReturnFormValues } from "@/components/reports/annual-return/add-modify-annual-return";
 import { Separator } from "@/components/ui/separator";
-import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "StockSync : Annual Return",

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,13 +1,14 @@
 import { Metadata } from "next";
-import MonthlyInvestment from "@/components/reports/monthly-investments";
-import YearlyInvestment from "@/components/reports/yearly-investments";
-import { Exchange } from "@/components/shared/exchange";
-import InvestmentReturn from "@/components/reports/investment-return";
-import InvestmentByBroker from "@/components/reports/investment-by-broker";
-import BrokerBalance from "@/components/reports/broker-balance";
-import YearlyDividend from "@/components/reports/yearly-dividend";
-import YearlySales from "@/components/reports/yearly-sales";
+
 import AnnualReturn from "@/components/reports/annual-return";
+import BrokerBalance from "@/components/reports/broker-balance";
+import InvestmentByBroker from "@/components/reports/investment-by-broker";
+import InvestmentReturn from "@/components/reports/investment-return";
+import MonthlyInvestment from "@/components/reports/monthly-investments";
+import YearlyDividend from "@/components/reports/yearly-dividend";
+import YearlyInvestment from "@/components/reports/yearly-investments";
+import YearlySales from "@/components/reports/yearly-sales";
+import { Exchange } from "@/components/shared/exchange";
 
 export const metadata: Metadata = {
   title: "StockSync : Report",

--- a/src/app/reports/purchase-detail-by-broker/[broker]/page.tsx
+++ b/src/app/reports/purchase-detail-by-broker/[broker]/page.tsx
@@ -1,5 +1,6 @@
-import PurchaseDetailByBroker from "@/components/reports/purchase-detail-by-broker/purchase-detail-by-broker";
 import { Metadata } from "next";
+
+import PurchaseDetailByBroker from "@/components/reports/purchase-detail-by-broker/purchase-detail-by-broker";
 
 export const metadata: Metadata = {
   title: "StockSync : Purchase detail by broker",

--- a/src/app/reports/purchase-detail/mf/[id]/page.tsx
+++ b/src/app/reports/purchase-detail/mf/[id]/page.tsx
@@ -1,5 +1,6 @@
-import StockPurchaseDetail from "@/components/reports/purchase-detail/stock-purchase-detail";
 import { Metadata } from "next";
+
+import StockPurchaseDetail from "@/components/reports/purchase-detail/stock-purchase-detail";
 
 export const metadata: Metadata = {
   title: "StockSync : Purchase detail",

--- a/src/app/reports/purchase-detail/stock/[id]/page.tsx
+++ b/src/app/reports/purchase-detail/stock/[id]/page.tsx
@@ -1,5 +1,6 @@
-import StockPurchaseDetail from "@/components/reports/purchase-detail/stock-purchase-detail";
 import { Metadata } from "next";
+
+import StockPurchaseDetail from "@/components/reports/purchase-detail/stock-purchase-detail";
 
 export const metadata: Metadata = {
   title: "StockSync : Purchase detail",

--- a/src/app/sales/stock/[id]/page.tsx
+++ b/src/app/sales/stock/[id]/page.tsx
@@ -1,7 +1,8 @@
-import { getStockInvestmentByID } from "@/actions/stock-investment.service";
-import InvestmentSales, { SalesFormValues } from "@/components/sales/investment-sales";
 import { toDate } from "date-fns";
 import { Metadata } from "next";
+
+import { getStockInvestmentByID } from "@/actions/stock-investment.service";
+import InvestmentSales, { SalesFormValues } from "@/components/sales/investment-sales";
 
 export const metadata: Metadata = {
   title: "StockSync : Sales",

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+
 import SyncPrices from "@/components/settings/sync-price";
 
 export const metadata: Metadata = {

--- a/src/components/companies/add-modify-company.tsx
+++ b/src/components/companies/add-modify-company.tsx
@@ -1,15 +1,16 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { addCompany, updateCompany } from "@/actions/company.service";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { EXCHANGE } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
-import { addCompany, updateCompany } from "@/actions/company.service";
 import { CompanyType } from "@/models/company.model";
 
 const companyFormSchema = z.object({

--- a/src/components/companies/data-table/columns.tsx
+++ b/src/components/companies/data-table/columns.tsx
@@ -2,11 +2,12 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 
-import { DataTableColumnHeader } from "./data-table-column-header";
-import { CompanyType } from "@/models/company.model";
-import { DataTableRowActions } from "./data-table-row-actions";
 import NumberFormater from "@/components/shared/number-format";
 import { convertToExchangeType } from "@/lib/utils";
+import { CompanyType } from "@/models/company.model";
+
+import { DataTableColumnHeader } from "./data-table-column-header";
+import { DataTableRowActions } from "./data-table-row-actions";
 
 export const Columns: ColumnDef<CompanyType>[] = [
   {

--- a/src/components/companies/data-table/data-table-column-header.tsx
+++ b/src/components/companies/data-table/data-table-column-header.tsx
@@ -2,8 +2,9 @@ import { ArrowDownIcon, ArrowUpIcon, CaretSortIcon, EyeNoneIcon } from "@radix-u
 import { Column } from "@tanstack/react-table";
 
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
+
 import { Button } from "../../ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
 
 interface DataTableColumnHeaderProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;

--- a/src/components/companies/data-table/data-table-faceted-filter.tsx
+++ b/src/components/companies/data-table/data-table-faceted-filter.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
 import { Column } from "@tanstack/react-table";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
+
 import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "../../ui/command";

--- a/src/components/companies/data-table/data-table-row-actions.tsx
+++ b/src/components/companies/data-table/data-table-row-actions.tsx
@@ -2,17 +2,17 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Row } from "@tanstack/react-table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deleteCompany } from "@/actions/company.service";
+import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
+import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
+import { CompanyType } from "@/models/company.model";
 
 import { Button } from "../../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from "../../ui/dropdown-menu";
-
-import { CompanyType } from "@/models/company.model";
-import Link from "next/link";
-import { deleteCompany } from "@/actions/company.service";
-import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
-import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>;

--- a/src/components/companies/data-table/data-table-toolbar.tsx
+++ b/src/components/companies/data-table/data-table-toolbar.tsx
@@ -2,11 +2,12 @@
 
 import { Cross2Icon, PlusIcon, QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { Table } from "@tanstack/react-table";
+import Link from "next/link";
+
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { DataTableFacetedFilter } from "./data-table-faceted-filter";
 import { DataTableViewOptions } from "./data-table-view-options";
-import Link from "next/link";
 
 const stockTypes = [
   {

--- a/src/components/companies/data-table/data-table.tsx
+++ b/src/components/companies/data-table/data-table.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import * as React from "react";
 import {
   ColumnDef,
   ColumnFiltersState,
-  SortingState,
-  VisibilityState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -13,11 +10,13 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  SortingState,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
+import * as React from "react";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../ui/table";
-
 import { DataTablePagination } from "./data-table-pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
 

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DashboardOverviewType } from "@/actions/dashboard.service";
-import { Overview } from "./tabs/overview";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
 import { Forecast } from "./tabs/forecast";
+import { Overview } from "./tabs/overview";
 import { Stocks } from "./tabs/stocks";
 
 type DashboardProps = {

--- a/src/components/dashboard/tabs/forecast.tsx
+++ b/src/components/dashboard/tabs/forecast.tsx
@@ -1,14 +1,16 @@
+import { faDollarSign, faGear, faIndianRupeeSign } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useEffect, useState } from "react";
+
 import { EstimatedReturnType, getEstimatedReturn } from "@/actions/dashboard.service";
 import NumberFormater from "@/components/shared/number-format";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { RecentSales } from "../recent-sales";
-import { Overview2 } from "./overview2";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDollarSign, faIndianRupeeSign, faGear } from "@fortawesome/free-solid-svg-icons";
+import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Label } from "@/components/ui/label";
-import { useEffect, useState } from "react";
+
+import { RecentSales } from "../recent-sales";
+import { Overview2 } from "./overview2";
 
 export function Forecast() {
   const [year, setYear] = useState("2042");

--- a/src/components/dashboard/tabs/overview.tsx
+++ b/src/components/dashboard/tabs/overview.tsx
@@ -1,11 +1,13 @@
-import { InvestmentReturnType, TotalInvestmentType, getInvestmentReturn, getTotalInvestment } from "@/actions/dashboard.service";
+import { faDollarSign, faHandHoldingDollar, faIndianRupeeSign } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useEffect, useState } from "react";
+
+import { getInvestmentReturn, getTotalInvestment, InvestmentReturnType, TotalInvestmentType } from "@/actions/dashboard.service";
 import NumberFormater from "@/components/shared/number-format";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
 import { RecentSales } from "../recent-sales";
 import { Overview2 } from "./overview2";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDollarSign, faIndianRupeeSign, faHandHoldingDollar } from "@fortawesome/free-solid-svg-icons";
-import { useEffect, useState } from "react";
 
 export function Overview() {
   const [totalInvestments, setTotalInvestments] = useState<TotalInvestmentType | null>(null);

--- a/src/components/dashboard/tabs/stocks.tsx
+++ b/src/components/dashboard/tabs/stocks.tsx
@@ -1,6 +1,7 @@
 import { DashboardOverviewType } from "@/actions/dashboard.service";
 import NumberFormater from "@/components/shared/number-format";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
 import { RecentSales } from "../recent-sales";
 import { Overview2 } from "./overview2";
 

--- a/src/components/deposit/add-modify-deposit.tsx
+++ b/src/components/deposit/add-modify-deposit.tsx
@@ -1,21 +1,23 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarIcon } from "@radix-ui/react-icons";
+import { format } from "date-fns";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { addDeposit, updateDeposit } from "@/actions/deposit.service";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { CURRENCY, DEPOSIT, DEPOSIT_TYPE } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
-import { addDeposit, updateDeposit } from "@/actions/deposit.service";
-import { DepositType } from "@/models/deposit.model";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { format } from "date-fns";
-import { CalendarIcon } from "@radix-ui/react-icons";
-import { Calendar } from "../ui/calendar";
 import { cn } from "@/lib/utils";
+import { DepositType } from "@/models/deposit.model";
+
+import { Calendar } from "../ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
 const FROM = ["Bank", "GROWW", "DHAN", "WEBULL", "Fidility - Roth", "Fidility - Traditional", "Fidility - Individual"];
 

--- a/src/components/deposit/data-table/columns.tsx
+++ b/src/components/deposit/data-table/columns.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+
+import NumberFormater from "@/components/shared/number-format";
+import { DepositType } from "@/models/deposit.model";
 
 import { DataTableColumnHeader } from "./data-table-column-header";
 import { DataTableRowActions } from "./data-table-row-actions";
-import { DepositType } from "@/models/deposit.model";
-import { format } from "date-fns";
-import NumberFormater from "@/components/shared/number-format";
 
 export const Columns: ColumnDef<DepositType>[] = [
   {

--- a/src/components/deposit/data-table/data-table-column-header.tsx
+++ b/src/components/deposit/data-table/data-table-column-header.tsx
@@ -2,8 +2,9 @@ import { ArrowDownIcon, ArrowUpIcon, CaretSortIcon, EyeNoneIcon } from "@radix-u
 import { Column } from "@tanstack/react-table";
 
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
+
 import { Button } from "../../ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
 
 interface DataTableColumnHeaderProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;

--- a/src/components/deposit/data-table/data-table-faceted-filter.tsx
+++ b/src/components/deposit/data-table/data-table-faceted-filter.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
 import { Column } from "@tanstack/react-table";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
+
 import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "../../ui/command";

--- a/src/components/deposit/data-table/data-table-row-actions.tsx
+++ b/src/components/deposit/data-table/data-table-row-actions.tsx
@@ -2,18 +2,18 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Row } from "@tanstack/react-table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deleteDeposit } from "@/actions/deposit.service";
+import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
+import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
+import { DEPOSIT_DIVIDEND_RECEIVED } from "@/lib/constants";
+import { DepositType } from "@/models/deposit.model";
 
 import { Button } from "../../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from "../../ui/dropdown-menu";
-
-import Link from "next/link";
-import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
-import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { DepositType } from "@/models/deposit.model";
-import { deleteDeposit } from "@/actions/deposit.service";
-import { DEPOSIT_DIVIDEND_RECEIVED } from "@/lib/constants";
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>;

--- a/src/components/deposit/data-table/data-table-toolbar.tsx
+++ b/src/components/deposit/data-table/data-table-toolbar.tsx
@@ -2,12 +2,14 @@
 
 import { Cross2Icon, PlusIcon, QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { Table } from "@tanstack/react-table";
+import Link from "next/link";
+
+import { DEPOSIT, DEPOSIT_TYPE } from "@/lib/constants";
+
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { DataTableFacetedFilter } from "./data-table-faceted-filter";
 import { DataTableViewOptions } from "./data-table-view-options";
-import Link from "next/link";
-import { DEPOSIT, DEPOSIT_TYPE } from "@/lib/constants";
 
 const currency = [
   {

--- a/src/components/deposit/data-table/data-table.tsx
+++ b/src/components/deposit/data-table/data-table.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import * as React from "react";
 import {
   ColumnDef,
   ColumnFiltersState,
-  SortingState,
-  VisibilityState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -13,14 +10,17 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  SortingState,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
+import * as React from "react";
+
+import { DEPOSIT } from "@/lib/constants";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../ui/table";
-
 import { DataTablePagination } from "./data-table-pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
-import { DEPOSIT } from "@/lib/constants";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   AlertTriangle,
   ArrowRight,
   Check,
@@ -24,7 +25,6 @@ import {
   Twitter,
   User,
   X,
-  Activity,
   // type Icon as LucideIcon,
 } from "lucide-react";
 

--- a/src/components/investments/mutual-fund/add-modify-mf-investment.tsx
+++ b/src/components/investments/mutual-fund/add-modify-mf-investment.tsx
@@ -1,25 +1,26 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarIcon } from "@radix-ui/react-icons";
+import { format } from "date-fns";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { getMFs } from "@/actions/mutual-fund.service";
+import { addMutualFundInvestment, updateMutualFundInvestment } from "@/actions/mutual-fund-investment.service";
+import { CustomNumericFormat } from "@/components/shared/number-format";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { BROKERS, CURRENCY } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { format } from "date-fns";
-import { Calendar } from "@/components/ui/calendar";
-import { CalendarIcon } from "@radix-ui/react-icons";
 import { cn } from "@/lib/utils";
-import { Label } from "@/components/ui/label";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
-import { addMutualFundInvestment, updateMutualFundInvestment } from "@/actions/mutual-fund-investment.service";
 import { MutualFundInvestmentType } from "@/models/mutual-fund-investment.model";
-import { getMFs } from "@/actions/mutual-fund.service";
-import { CustomNumericFormat } from "@/components/shared/number-format";
 
 const mutualFundInvestmentFormSchema = z.object({
   mutualFundID: z.string(),

--- a/src/components/investments/mutual-fund/data-table/columns.tsx
+++ b/src/components/investments/mutual-fund/data-table/columns.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+
+import NumberFormater from "@/components/shared/number-format";
+import { Badge } from "@/components/ui/badge";
+import MutualFundInvestment from "@/models/mutual-fund-investment.model";
 
 import { DataTableColumnHeader } from "./data-table-column-header";
 import { DataTableRowActions } from "./data-table-row-actions";
-import { format } from "date-fns";
-import MutualFundInvestment from "@/models/mutual-fund-investment.model";
-import { Badge } from "@/components/ui/badge";
-import NumberFormater from "@/components/shared/number-format";
 
 export const Columns: ColumnDef<MutualFundInvestment>[] = [
   {

--- a/src/components/investments/mutual-fund/data-table/data-table-column-header.tsx
+++ b/src/components/investments/mutual-fund/data-table/data-table-column-header.tsx
@@ -2,8 +2,9 @@ import { ArrowDownIcon, ArrowUpIcon, CaretSortIcon, EyeNoneIcon } from "@radix-u
 import { Column } from "@tanstack/react-table";
 
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../../ui/dropdown-menu";
+
 import { Button } from "../../../ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../../ui/dropdown-menu";
 
 interface DataTableColumnHeaderProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;

--- a/src/components/investments/mutual-fund/data-table/data-table-faceted-filter.tsx
+++ b/src/components/investments/mutual-fund/data-table/data-table-faceted-filter.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
 import { Column } from "@tanstack/react-table";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
+
 import { Badge } from "../../../ui/badge";
 import { Button } from "../../../ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "../../../ui/command";

--- a/src/components/investments/mutual-fund/data-table/data-table-row-actions.tsx
+++ b/src/components/investments/mutual-fund/data-table/data-table-row-actions.tsx
@@ -2,6 +2,14 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Row } from "@tanstack/react-table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deleteMutualFundInvestment } from "@/actions/mutual-fund-investment.service";
+import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
+import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
+import MutualFundInvestment from "@/models/mutual-fund-investment.model";
 
 import { Button } from "../../../ui/button";
 import {
@@ -12,14 +20,6 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "../../../ui/dropdown-menu";
-
-import Link from "next/link";
-import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
-import { useRouter } from "next/navigation";
-import MutualFundInvestment from "@/models/mutual-fund-investment.model";
-import { useState } from "react";
-import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
-import { deleteMutualFundInvestment } from "@/actions/mutual-fund-investment.service";
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>;

--- a/src/components/investments/mutual-fund/data-table/data-table-toolbar.tsx
+++ b/src/components/investments/mutual-fund/data-table/data-table-toolbar.tsx
@@ -2,12 +2,14 @@
 
 import { Cross2Icon, PlusIcon } from "@radix-ui/react-icons";
 import { Table } from "@tanstack/react-table";
+import Link from "next/link";
+
+import { BROKERS } from "@/lib/constants";
+
 import { Button } from "../../../ui/button";
 import { Input } from "../../../ui/input";
 import { DataTableFacetedFilter } from "./data-table-faceted-filter";
 import { DataTableViewOptions } from "./data-table-view-options";
-import { BROKERS } from "@/lib/constants";
-import Link from "next/link";
 
 const brokerTypes = BROKERS;
 

--- a/src/components/investments/mutual-fund/data-table/data-table.tsx
+++ b/src/components/investments/mutual-fund/data-table/data-table.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import * as React from "react";
 import {
   ColumnDef,
   ColumnFiltersState,
-  SortingState,
-  VisibilityState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -13,11 +10,13 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  SortingState,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
+import * as React from "react";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../ui/table";
-
 import { DataTablePagination } from "./data-table-pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
 // import { DataTableToolbar } from "./data-table-toolbar";

--- a/src/components/investments/stocks/add-modify-stock-investment.tsx
+++ b/src/components/investments/stocks/add-modify-stock-investment.tsx
@@ -1,25 +1,26 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarIcon } from "@radix-ui/react-icons";
+import { format } from "date-fns";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { getCompanies } from "@/actions/company.service";
+import { addStockInvestment, updateStockInvestment } from "@/actions/stock-investment.service";
+import { CustomNumericFormat } from "@/components/shared/number-format";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { BROKERS, CURRENCY } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { format } from "date-fns";
-import { Calendar } from "@/components/ui/calendar";
-import { CalendarIcon } from "@radix-ui/react-icons";
 import { cn } from "@/lib/utils";
-import { Label } from "@/components/ui/label";
-import { useEffect, useState } from "react";
-import { addStockInvestment, updateStockInvestment } from "@/actions/stock-investment.service";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
-import { getCompanies } from "@/actions/company.service";
 import { StockInvestmentType } from "@/models/stock-investment.model";
-import { CustomNumericFormat } from "@/components/shared/number-format";
 
 const stockInvestmentFormSchema = z.object({
   companyID: z.string(),

--- a/src/components/investments/stocks/data-table/columns.tsx
+++ b/src/components/investments/stocks/data-table/columns.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+
+import { CustomNumericFormat } from "@/components/shared/number-format";
+import { StockInvestmentType } from "@/models/stock-investment.model";
 
 import { DataTableColumnHeader } from "./data-table-column-header";
 import { DataTableRowActions } from "./data-table-row-actions";
-import { StockInvestmentType } from "@/models/stock-investment.model";
-import { format } from "date-fns";
-import { CustomNumericFormat } from "@/components/shared/number-format";
 
 export const Columns: ColumnDef<StockInvestmentType>[] = [
   {

--- a/src/components/investments/stocks/data-table/data-table-column-header.tsx
+++ b/src/components/investments/stocks/data-table/data-table-column-header.tsx
@@ -2,8 +2,9 @@ import { ArrowDownIcon, ArrowUpIcon, CaretSortIcon, EyeNoneIcon } from "@radix-u
 import { Column } from "@tanstack/react-table";
 
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../../ui/dropdown-menu";
+
 import { Button } from "../../../ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../../ui/dropdown-menu";
 
 interface DataTableColumnHeaderProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;

--- a/src/components/investments/stocks/data-table/data-table-faceted-filter.tsx
+++ b/src/components/investments/stocks/data-table/data-table-faceted-filter.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
 import { Column } from "@tanstack/react-table";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
+
 import { Badge } from "../../../ui/badge";
 import { Button } from "../../../ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "../../../ui/command";

--- a/src/components/investments/stocks/data-table/data-table-row-actions.tsx
+++ b/src/components/investments/stocks/data-table/data-table-row-actions.tsx
@@ -2,6 +2,14 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Row } from "@tanstack/react-table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deleteStockInvestment } from "@/actions/stock-investment.service";
+import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
+import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
+import StockInvestment from "@/models/stock-investment.model";
 
 import { Button } from "../../../ui/button";
 import {
@@ -12,14 +20,6 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "../../../ui/dropdown-menu";
-
-import Link from "next/link";
-import StockInvestment from "@/models/stock-investment.model";
-import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
-import { deleteStockInvestment } from "@/actions/stock-investment.service";
-import { useRouter } from "next/navigation";
-import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
-import { useState } from "react";
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>;

--- a/src/components/investments/stocks/data-table/data-table-toolbar.tsx
+++ b/src/components/investments/stocks/data-table/data-table-toolbar.tsx
@@ -2,12 +2,14 @@
 
 import { Cross2Icon, PlusIcon } from "@radix-ui/react-icons";
 import { Table } from "@tanstack/react-table";
+import Link from "next/link";
+
+import { BROKERS } from "@/lib/constants";
+
 import { Button } from "../../../ui/button";
 import { Input } from "../../../ui/input";
 import { DataTableFacetedFilter } from "./data-table-faceted-filter";
 import { DataTableViewOptions } from "./data-table-view-options";
-import { BROKERS } from "@/lib/constants";
-import Link from "next/link";
 
 const brokerTypes = BROKERS;
 

--- a/src/components/investments/stocks/data-table/data-table.tsx
+++ b/src/components/investments/stocks/data-table/data-table.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import * as React from "react";
 import {
   ColumnDef,
   ColumnFiltersState,
-  SortingState,
-  VisibilityState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -13,11 +10,13 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  SortingState,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
+import * as React from "react";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../ui/table";
-
 import { DataTablePagination } from "./data-table-pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
 

--- a/src/components/main-nav.tsx
+++ b/src/components/main-nav.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { cn } from "@/lib/utils";
+import Link from "next/link";
+import React from "react";
+
 import { Icons } from "@/components/icons";
 import {
   NavigationMenu,
@@ -10,8 +12,7 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
-import React from "react";
-import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 const components: { title: string; href: string; description: string }[] = [
   {

--- a/src/components/mutual-fund/add-modify-mutualfund.tsx
+++ b/src/components/mutual-fund/add-modify-mutualfund.tsx
@@ -1,21 +1,23 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { addMF, updateMF } from "@/actions/mutual-fund.service";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { EXCHANGE } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
-import { addMF, updateMF } from "@/actions/mutual-fund.service";
 import { MutualFundType } from "@/models/mutual-fund.model";
+
 import { Switch } from "../ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
-import Link from "next/link";
 
 const mutualFundFormSchema = z.object({
   name: z.string().min(1),

--- a/src/components/mutual-fund/data-table/columns.tsx
+++ b/src/components/mutual-fund/data-table/columns.tsx
@@ -2,10 +2,11 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 
+import { CustomNumericFormat } from "@/components/shared/number-format";
+import { MutualFundType } from "@/models/mutual-fund.model";
+
 import { DataTableColumnHeader } from "../../companies/data-table/data-table-column-header";
 import { DataTableRowActions } from "./data-table-row-actions";
-import { MutualFundType } from "@/models/mutual-fund.model";
-import { CustomNumericFormat } from "@/components/shared/number-format";
 
 export const Columns: ColumnDef<MutualFundType>[] = [
   {

--- a/src/components/mutual-fund/data-table/data-table-column-header.tsx
+++ b/src/components/mutual-fund/data-table/data-table-column-header.tsx
@@ -2,8 +2,9 @@ import { ArrowDownIcon, ArrowUpIcon, CaretSortIcon, EyeNoneIcon } from "@radix-u
 import { Column } from "@tanstack/react-table";
 
 import { cn } from "@/lib/utils";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
+
 import { Button } from "../../ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
 
 interface DataTableColumnHeaderProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;

--- a/src/components/mutual-fund/data-table/data-table-faceted-filter.tsx
+++ b/src/components/mutual-fund/data-table/data-table-faceted-filter.tsx
@@ -1,8 +1,9 @@
-import * as React from "react";
 import { CheckIcon, PlusCircledIcon } from "@radix-ui/react-icons";
 import { Column } from "@tanstack/react-table";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
+
 import { Badge } from "../../ui/badge";
 import { Button } from "../../ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "../../ui/command";

--- a/src/components/mutual-fund/data-table/data-table-row-actions.tsx
+++ b/src/components/mutual-fund/data-table/data-table-row-actions.tsx
@@ -2,17 +2,17 @@
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Row } from "@tanstack/react-table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { deleteMF } from "@/actions/mutual-fund.service";
+import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
+import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
+import { MutualFundType } from "@/models/mutual-fund.model";
 
 import { Button } from "../../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from "../../ui/dropdown-menu";
-
-import Link from "next/link";
-import { MutualFundType } from "@/models/mutual-fund.model";
-import { useState } from "react";
-import { deleteMF } from "@/actions/mutual-fund.service";
-import { toastDBDeleteSuccess, toastDBSaveError } from "@/components/shared/toast-message";
-import { DeleteConfirmation } from "@/components/shared/delete-confirmation";
-import { useRouter } from "next/navigation";
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>;

--- a/src/components/mutual-fund/data-table/data-table-toolbar.tsx
+++ b/src/components/mutual-fund/data-table/data-table-toolbar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { PlusIcon } from "@radix-ui/react-icons";
 import { Table } from "@tanstack/react-table";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
 import { Input } from "../../ui/input";
 import { DataTableViewOptions } from "./data-table-view-options";
-import { Button } from "@/components/ui/button";
-import { PlusIcon } from "@radix-ui/react-icons";
-import Link from "next/link";
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;

--- a/src/components/mutual-fund/data-table/data-table.tsx
+++ b/src/components/mutual-fund/data-table/data-table.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import * as React from "react";
 import {
   ColumnDef,
   ColumnFiltersState,
-  SortingState,
-  VisibilityState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -13,11 +10,13 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  SortingState,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
+import * as React from "react";
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../ui/table";
-
 import { DataTablePagination } from "./data-table-pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
 

--- a/src/components/reports/annual-return.tsx
+++ b/src/components/reports/annual-return.tsx
@@ -1,13 +1,14 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import NumberFormater, { CustomNumericFormat } from "../shared/number-format";
 import { useEffect, useState } from "react";
-import { useStockSyncStore } from "@/store/store";
 import { useShallow } from "zustand/react/shallow";
-import { AnnualReturnType } from "@/models/annual-return.model";
+
 import { getAnnualReturn } from "@/actions/annual-return.service";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { AnnualReturnType } from "@/models/annual-return.model";
+import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater, { CustomNumericFormat } from "../shared/number-format";
 import { Button } from "../ui/button";
-import Link from "next/link";
 
 export default function AnnualReturn() {
   const [annualReturns, setAnnualReturns] = useState<AnnualReturnType[]>([]);

--- a/src/components/reports/annual-return/add-modify-annual-return.tsx
+++ b/src/components/reports/annual-return/add-modify-annual-return.tsx
@@ -1,16 +1,17 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { addAnnualReturn, updateAnnualReturn } from "@/actions/annual-return.service";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { EXCHANGE } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
 import { AnnualReturnType } from "@/models/annual-return.model";
-import { addAnnualReturn, updateAnnualReturn } from "@/actions/annual-return.service";
 
 const YEARS = ["2020", "2021", "2022", "2023", "2024"];
 const annualReturnFormSchema = z.object({

--- a/src/components/reports/broker-balance.tsx
+++ b/src/components/reports/broker-balance.tsx
@@ -1,10 +1,12 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { BrokerBalanceType, getBrokerBalance } from "@/actions/report.service";
-import NumberFormater, { CustomNumericFormat } from "../shared/number-format";
 import { useEffect, useState } from "react";
-import { useStockSyncStore } from "@/store/store";
 import { useShallow } from "zustand/react/shallow";
+
+import { BrokerBalanceType, getBrokerBalance } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater, { CustomNumericFormat } from "../shared/number-format";
 
 export default function BrokerBalance() {
   const [balance, setBalance] = useState<BrokerBalanceType | null>(null);

--- a/src/components/reports/investment-by-broker.tsx
+++ b/src/components/reports/investment-by-broker.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { InvestmentByBrokerType, getInvestmentByBroker } from "@/actions/report.service";
-import NumberFormater from "../shared/number-format";
 import { useEffect, useState } from "react";
-import { Switch } from "../ui/switch";
-import { useStockSyncStore } from "@/store/store";
 import { useShallow } from "zustand/react/shallow";
+
+import { getInvestmentByBroker, InvestmentByBrokerType } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater from "../shared/number-format";
+import { Switch } from "../ui/switch";
 
 export default function InvestmentByBroker() {
   const [data, setData] = useState<InvestmentByBrokerType | null>(null);

--- a/src/components/reports/investment-return.tsx
+++ b/src/components/reports/investment-return.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { ExpectedReturnType, expectedReturn } from "@/actions/report.service";
-import NumberFormater from "../shared/number-format";
 import { useEffect, useState } from "react";
-import { useStockSyncStore } from "@/store/store";
 import { useShallow } from "zustand/react/shallow";
-import Link from "next/link";
+
+import { expectedReturn, ExpectedReturnType } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater from "../shared/number-format";
 import { Button } from "../ui/button";
 
 export default function InvestmentReturn() {

--- a/src/components/reports/monthly-investments.tsx
+++ b/src/components/reports/monthly-investments.tsx
@@ -1,12 +1,14 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Badge } from "../ui/badge";
-import { MonthlyInvestmentType, getMonthlyInvestments } from "@/actions/report.service";
 import { format } from "date-fns";
-import NumberFormater from "../shared/number-format";
 import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+
+import { getMonthlyInvestments, MonthlyInvestmentType } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater from "../shared/number-format";
+import { Badge } from "../ui/badge";
 
 export default function MonthlyInvestment() {
   const [investments, setInvestments] = useState<MonthlyInvestmentType[]>([]);

--- a/src/components/reports/purchase-detail-by-broker/purchase-detail-by-broker.tsx
+++ b/src/components/reports/purchase-detail-by-broker/purchase-detail-by-broker.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { PurchaseDetailByBrokerType, getPurchaseDetailByBroker } from "@/actions/purchase-detail.service";
+import { format } from "date-fns";
+import { useEffect, useState } from "react";
+
+import { getPurchaseDetailByBroker, PurchaseDetailByBrokerType } from "@/actions/purchase-detail.service";
 import NumberFormater, { CustomNumericFormat } from "@/components/shared/number-format";
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import { useEffect, useState } from "react";
 
 type StockPurchaseDetailByBrokerProps = {
   broker: string;

--- a/src/components/reports/purchase-detail/stock-purchase-detail.tsx
+++ b/src/components/reports/purchase-detail/stock-purchase-detail.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { InvestmentDetailType, PurchaseDetailType, getPurchaseDetail } from "@/actions/purchase-detail.service";
+import { format } from "date-fns";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { getPurchaseDetail, InvestmentDetailType, PurchaseDetailType } from "@/actions/purchase-detail.service";
 import NumberFormater, { CustomNumericFormat } from "@/components/shared/number-format";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { StockOrMutualFundType } from "@/lib/constants";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
-import Link from "next/link";
-import { useEffect, useState } from "react";
 
 type StockPurchaseDetailProps = {
   id: number;

--- a/src/components/reports/yearly-dividend.tsx
+++ b/src/components/reports/yearly-dividend.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { YearlyDividendType, getYearlyDividend } from "@/actions/report.service";
-import NumberFormater from "../shared/number-format";
-import { useEffect, useState } from "react";
 import { sumBy } from "lodash";
+import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+
+import { getYearlyDividend, YearlyDividendType } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater from "../shared/number-format";
 
 export default function YearlyDividend() {
   const [dividend, setDividend] = useState<YearlyDividendType[]>([]);

--- a/src/components/reports/yearly-investments.tsx
+++ b/src/components/reports/yearly-investments.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { YearlyInvestmentType, getYearlyInvestments } from "@/actions/report.service";
-import NumberFormater from "../shared/number-format";
-import { useEffect, useState } from "react";
 import { sumBy } from "lodash";
-import { useStockSyncStore } from "@/store/store";
+import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+
+import { getYearlyInvestments, YearlyInvestmentType } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater from "../shared/number-format";
 
 export default function YearlyInvestment() {
   const [investments, setInvestments] = useState<YearlyInvestmentType[]>([]);

--- a/src/components/reports/yearly-sales.tsx
+++ b/src/components/reports/yearly-sales.tsx
@@ -1,10 +1,12 @@
 "use client";
-import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { TotalSaleByYear, getTotalSales } from "@/actions/report.service";
-import NumberFormater from "../shared/number-format";
 import { useEffect, useState } from "react";
-import { useStockSyncStore } from "@/store/store";
 import { useShallow } from "zustand/react/shallow";
+
+import { getTotalSales, TotalSaleByYear } from "@/actions/report.service";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useStockSyncStore } from "@/store/store";
+
+import NumberFormater from "../shared/number-format";
 
 export default function YearlySales() {
   const [sales, setSales] = useState<TotalSaleByYear | null>(null);

--- a/src/components/sales/investment-sales.tsx
+++ b/src/components/sales/investment-sales.tsx
@@ -1,22 +1,24 @@
 "use client";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarIcon } from "@radix-ui/react-icons";
+import { format } from "date-fns";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+
+import { addSales } from "@/actions/sale.service";
+import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { StockOrMutualFundType } from "@/lib/constants";
-import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
-import { toastDBSaveError, toastDBSaveSuccess } from "@/components/shared/toast-message";
-import { addSales } from "@/actions/sale.service";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { CalendarIcon } from "@radix-ui/react-icons";
 import { cn } from "@/lib/utils";
-import { format } from "date-fns";
+
+import { CustomNumericFormat } from "../shared/number-format";
 import { Calendar } from "../ui/calendar";
 import { Label } from "../ui/label";
-import { CustomNumericFormat } from "../shared/number-format";
-import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
 const salesFormSchema = z.object({
   company: z.string().min(1),

--- a/src/components/settings/sync-price.tsx
+++ b/src/components/settings/sync-price.tsx
@@ -1,12 +1,14 @@
 "use client";
+import { round } from "lodash";
+import { useState } from "react";
+
 import { getCompanies, updateCompany } from "@/actions/company.service";
+import { getMFs, updateMF } from "@/actions/mutual-fund.service";
+import { getUSAStockPrice, syncStockPrice } from "@/actions/setting.service";
+
 import { Button } from "../ui/button";
 import { Label } from "../ui/label";
 import { Progress } from "../ui/progress";
-import { round } from "lodash";
-import { useState } from "react";
-import { getUSAStockPrice, syncStockPrice } from "@/actions/setting.service";
-import { getMFs, updateMF } from "@/actions/mutual-fund.service";
 import { toast } from "../ui/use-toast";
 
 type FetchStatus = {

--- a/src/components/shared/delete-confirmation.test.tsx
+++ b/src/components/shared/delete-confirmation.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { DeleteConfirmation } from "./delete-confirmation";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DeleteConfirmation } from "./delete-confirmation";
 
 describe("DeleteConfirmation", () => {
   afterEach(() => {

--- a/src/components/shared/exchange.tsx
+++ b/src/components/shared/exchange.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useShallow } from "zustand/react/shallow";
+
+import { useStockSyncStore } from "@/store/store";
+
 import { Label } from "../ui/label";
 import { RadioGroup, RadioGroupItem } from "../ui/radio-group";
-import { useStockSyncStore } from "@/store/store";
 
 export function Exchange() {
   const { exchange, changeExchange } = useStockSyncStore(

--- a/src/components/shared/number-format.test.tsx
+++ b/src/components/shared/number-format.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
 import NumberFormater from "./number-format";
 
 describe("NumberFormater", () => {

--- a/src/components/shared/number-format.tsx
+++ b/src/components/shared/number-format.tsx
@@ -1,5 +1,6 @@
-import { EXCHANGE_TYPE } from "@/lib/constants";
 import { NumberFormatBase, NumericFormat } from "react-number-format";
+
+import { EXCHANGE_TYPE } from "@/lib/constants";
 
 type NumberFormaterProps = {
   value: string | number;

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import * as React from "react";
 
-import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -83,14 +83,14 @@ AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
-  AlertDialogPortal,
-  AlertDialogOverlay,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -24,4 +24,4 @@ const AvatarFallback = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.
 );
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
-export { Avatar, AvatarImage, AvatarFallback };
+export { Avatar, AvatarFallback, AvatarImage };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import * as React from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import * as React from "react";
 import { DayPicker } from "react-day-picker";
 
-import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,4 +32,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 ));
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { Check } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import * as React from "react";
 import { type DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
+import * as React from "react";
 
-import { cn } from "@/lib/utils";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 
 const Command = React.forwardRef<React.ElementRef<typeof CommandPrimitive>, React.ComponentPropsWithoutRef<typeof CommandPrimitive>>(
   ({ className, ...props }, ref) => (
@@ -104,4 +104,4 @@ const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanE
 };
 CommandShortcut.displayName = "CommandShortcut";
 
-export { Command, CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandShortcut, CommandSeparator };
+export { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -74,4 +74,4 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />);
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-export { Dialog, DialogPortal, DialogOverlay, DialogClose, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };
+export { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -158,18 +158,18 @@ DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuTrigger,
 };

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
 import { Controller, ControllerProps, FieldPath, FieldValues, FormProvider, useFormContext } from "react-hook-form";
 
-import { cn } from "@/lib/utils";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 const Form = FormProvider;
 
@@ -111,4 +111,4 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<
 });
 FormMessage.displayName = "FormMessage";
 
-export { useFormField, Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };
+export { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage, useFormField };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDown } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -92,13 +92,13 @@ const NavigationMenuIndicator = React.forwardRef<
 NavigationMenuIndicator.displayName = NavigationMenuPrimitive.Indicator.displayName;
 
 export {
-  navigationMenuTriggerStyle,
   NavigationMenu,
-  NavigationMenuList,
-  NavigationMenuItem,
   NavigationMenuContent,
-  NavigationMenuTrigger,
-  NavigationMenuLink,
   NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
   NavigationMenuViewport,
 };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -27,4 +27,4 @@ const PopoverContent = React.forwardRef<React.ElementRef<typeof PopoverPrimitive
 );
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent };
+export { Popover, PopoverContent, PopoverTrigger };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { Circle } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -112,13 +112,13 @@ SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
-  SelectGroup,
-  SelectValue,
-  SelectTrigger,
   SelectContent,
-  SelectLabel,
+  SelectGroup,
   SelectItem,
-  SelectSeparator,
-  SelectScrollUpButton,
+  SelectLabel,
   SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
 };

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -44,4 +44,4 @@ const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttribu
 ));
 TableCaption.displayName = "TableCaption";
 
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -46,4 +46,4 @@ const TabsContent = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Conte
 );
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import * as React from "react";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -92,4 +92,4 @@ type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
-export { type ToastProps, type ToastActionElement, ToastProvider, ToastViewport, Toast, ToastTitle, ToastDescription, ToastClose, ToastAction };
+export { Toast, ToastAction, type ToastActionElement, ToastClose, ToastDescription, type ToastProps, ToastProvider, ToastTitle, ToastViewport };

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -15,6 +15,7 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
+// eslint-disable-next-line unused-imports/no-unused-vars
 const actionTypes = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",
@@ -187,4 +188,4 @@ function useToast() {
   };
 }
 
-export { useToast, toast };
+export { toast, useToast };

--- a/src/lib/financial.test.ts
+++ b/src/lib/financial.test.ts
@@ -1,8 +1,9 @@
 import { cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest";
-import { calculateCAGR, calculateInterest, calculateXIRR, customDifferenceInDays, customDifferenceInYears } from "./financial";
 import { sub } from "date-fns";
 import { round } from "lodash";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { calculateCAGR, calculateInterest, calculateXIRR, customDifferenceInDays, customDifferenceInYears } from "./financial";
 
 describe("Financial Methods", () => {
   afterEach(() => {

--- a/src/lib/financial.ts
+++ b/src/lib/financial.ts
@@ -1,9 +1,9 @@
 // import moment = require("moment");
-import { interest, compoundAnnualGrowthRate } from "capitaljs";
+import { compoundAnnualGrowthRate, interest } from "capitaljs";
 import { differenceInDays, differenceInYears } from "date-fns";
 import { orderBy, round } from "lodash";
 // var xirr = require("xirr");
-import { xirr, convertRate, RateInterval } from "node-irr";
+import { convertRate, RateInterval, xirr } from "node-irr";
 // const { xirr } = require("node-irr");
 
 /**

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import { cleanup } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
 import { convertToExchangeType } from "./utils";
 
 describe("Utility Methods", () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+
 import { EXCHANGE_TYPE } from "./constants";
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/models/annual-return.model.ts
+++ b/src/models/annual-return.model.ts
@@ -1,4 +1,4 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement } from "sequelize-typescript";
+import { AutoIncrement, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
 
 export type AnnualReturnType = {
   id?: number;

--- a/src/models/company.model.ts
+++ b/src/models/company.model.ts
@@ -1,4 +1,5 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement, HasMany } from "sequelize-typescript";
+import { AutoIncrement, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
 import StockInvestment from "./stock-investment.model";
 
 export type CompanyType = {

--- a/src/models/deposit.model.ts
+++ b/src/models/deposit.model.ts
@@ -1,4 +1,4 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement } from "sequelize-typescript";
+import { AutoIncrement, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
 
 export type DepositType = {
   id?: number;

--- a/src/models/mutual-fund-investment.model.ts
+++ b/src/models/mutual-fund-investment.model.ts
@@ -1,4 +1,5 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement, BelongsTo, ForeignKey } from "sequelize-typescript";
+import { AutoIncrement, BelongsTo, Column, ForeignKey, Model, PrimaryKey, Table } from "sequelize-typescript";
+
 import MutualFund from "./mutual-fund.model";
 
 export type MutualFundInvestmentType = {

--- a/src/models/mutual-fund.model.ts
+++ b/src/models/mutual-fund.model.ts
@@ -1,4 +1,4 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement } from "sequelize-typescript";
+import { AutoIncrement, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
 
 export type MutualFundType = {
   id?: number;

--- a/src/models/sale.model.ts
+++ b/src/models/sale.model.ts
@@ -1,4 +1,4 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement } from "sequelize-typescript";
+import { AutoIncrement, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
 
 export type SaleType = {
   company: string;

--- a/src/models/stock-investment.model.ts
+++ b/src/models/stock-investment.model.ts
@@ -1,4 +1,5 @@
-import { Model, Column, Table, PrimaryKey, AutoIncrement, BelongsTo, ForeignKey } from "sequelize-typescript";
+import { AutoIncrement, BelongsTo, Column, ForeignKey, Model, PrimaryKey, Table } from "sequelize-typescript";
+
 import Company from "./company.model";
 
 export type StockInvestmentType = {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,7 +1,8 @@
-import { EXCHANGE_TYPE } from "@/lib/constants";
-import { StateCreator, create } from "zustand";
+import { create, StateCreator } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
+
+import { EXCHANGE_TYPE } from "@/lib/constants";
 
 // const customMiddlewares = f => devtools(persist(immer(f), { name: "stockSync" }));
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
+
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
### Summary

This PR cleans up the codebase by:
- Automatically removing unused imports
- Sorting all import statements consistently

### Details

Configured ESLint with:
- `eslint-plugin-unused-imports` to remove unused imports and variables
- `eslint-plugin-simple-import-sort` to sort imports and exports

Also ran `eslint --fix` across the project to apply these changes.

### Why

Improves code readability, reduces clutter, and enforces a consistent import style across the codebase.

### Notes

No functional changes included. This is a non-breaking refactor for better maintainability.
